### PR TITLE
add shield for Laravel framework version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# dashboard.spatie.be
+# dashboard.spatie.be [![Composer Cache](https://shield.with.social/cc/github/spatie/dashboard.spatie.be/master.svg?style=flat-square)](https://packagist.org/packages/laravel/framework)
 
 This repo contains the source code of https://dashboard.spatie.be
 


### PR DESCRIPTION
This is a site me and bobbybouwmann made https://shield.with.social
It pulls in the Laravel/framework version that is currently in the composer.lock file.

Hope it's okay to add this in to the readme :)