### PR TITLE
Update RainForecast.vue

### DIFF
--- a/resources/assets/js/components/RainForecast.vue
+++ b/resources/assets/js/components/RainForecast.vue
@@ -62,7 +62,7 @@ export default {
                 return foreCastItem.chanceOfRain < 40;
             }).length;
 
-            return foreCastItemWithNoRain.length === 0;
+            return foreCastItemWithNoRain === 0;
         },
 
         graphLabels() {


### PR DESCRIPTION
`foreCastItemWithNoRain` already contains the length of all items smaller than 40.