### PR TITLE
[WIP] Add an NPM statistic tile

### DIFF
--- a/app/Console/Components/Npm/FetchTotals.php
+++ b/app/Console/Components/Npm/FetchTotals.php
@@ -17,25 +17,7 @@ class FetchTotals extends Command
     {
         $npmStats = new NpmStats(new Client());
 
-        $packageList = collect([
-            "spatie-scss",
-            "form-backend-validation",
-            "vue-save-state",
-            "@spatie/blender-js",
-            "npm-install-peers",
-            "eslint-config-spatie",
-            "vue-tabs-component",
-            "@spatie/blender-css",
-            "vue-expose-inject",
-            "@spatie/blender-media",
-            "vue-table-component",
-            "@spatie/blender-content-blocks",
-            "font-awesome-filetypes",
-            "@spatie/attachment-uploader",
-            "postcss-assign",
-            "@spatie/scss",
-            "spatie-dom"
-        ]);
+        $packageList = $this->getPackageList();
 
         /*
          * First idea was to filter the non-scoped and scoped packages so at least the
@@ -73,5 +55,28 @@ class FetchTotals extends Command
         dd($totals);
 
         event(new TotalsFetched($totals));
+    }
+
+    private function getPackageList()
+    {
+        return collect([
+            "spatie-scss",
+            "form-backend-validation",
+            "vue-save-state",
+            "@spatie/blender-js",
+            "npm-install-peers",
+            "eslint-config-spatie",
+            "vue-tabs-component",
+            "@spatie/blender-css",
+            "vue-expose-inject",
+            "@spatie/blender-media",
+            "vue-table-component",
+            "@spatie/blender-content-blocks",
+            "font-awesome-filetypes",
+            "@spatie/attachment-uploader",
+            "postcss-assign",
+            "@spatie/scss",
+            "spatie-dom"
+        ]);
     }
 }

--- a/app/Console/Components/Npm/FetchTotals.php
+++ b/app/Console/Components/Npm/FetchTotals.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Console\Components\Npm;
+
+use App\Events\Packagist\TotalsFetched;
+use Developmint\NpmStats\NpmStats;
+use GuzzleHttp\Client;
+use Illuminate\Console\Command;
+
+class FetchTotals extends Command
+{
+    protected $signature = 'dashboard:fetch-npm-totals';
+
+    protected $description = 'Fetch totals for all our NPM packages';
+
+    public function handle()
+    {
+        $npmStats = new NpmStats(new Client());
+
+        $packageList = collect([
+            "spatie-scss",
+            "form-backend-validation",
+            "vue-save-state",
+            "@spatie/blender-js",
+            "npm-install-peers",
+            "eslint-config-spatie",
+            "vue-tabs-component",
+            "@spatie/blender-css",
+            "vue-expose-inject",
+            "@spatie/blender-media",
+            "vue-table-component",
+            "@spatie/blender-content-blocks",
+            "font-awesome-filetypes",
+            "@spatie/attachment-uploader",
+            "postcss-assign",
+            "@spatie/scss",
+            "spatie-dom"
+        ]);
+
+        /*
+         * First idea was to filter the non-scoped and scoped packages so at least the
+         * scoped packages could've been processed by bulk. This would work, but the
+         * allowed range for bulk is lower than normal, which would lead to wrong,
+         * incomplete or weird data in some cases
+         *
+
+        $packages = $packageList->filter(function ($package) {
+            return strpos($package, "@") === 0;
+        });
+
+        $nonScoped = $packageList->diff($packages);
+
+        $bulkString = substr($nonScoped->reduce(function ($bulkString, $package) {
+            $bulkString .= "{$package},";
+
+            return $bulkString;
+        }, ""), 0, -1);
+
+        $packages->push($bulkString);
+
+        */
+
+
+        //Let's take the most naive approach by now! But.. 3 calls per package, 16 packages -> 48 calls. Damn!
+
+        $totals = $packageList->reduce(function ($carry, $package) use ($npmStats) {
+
+            $carry["daily"] += $npmStats->getStats($package)["downloads"];
+            $carry["monthly"] += $npmStats->getStats($package, NpmStats::LAST_MONTH)["downloads"];
+            $carry["total"] += $npmStats->getStats($package, NpmStats::TOTAL)["downloads"];
+
+            return $carry;
+        }, ["daily" => 0, "monthly" => 0, "total" => 0]);
+
+        event(new TotalsFetched($totals));
+    }
+}

--- a/app/Console/Components/Npm/FetchTotals.php
+++ b/app/Console/Components/Npm/FetchTotals.php
@@ -2,7 +2,7 @@
 
 namespace App\Console\Components\Npm;
 
-use App\Events\Packagist\TotalsFetched;
+use App\Events\Npm\TotalsFetched;
 use Developmint\NpmStats\NpmStats;
 use GuzzleHttp\Client;
 use Illuminate\Console\Command;

--- a/app/Console/Components/Npm/FetchTotals.php
+++ b/app/Console/Components/Npm/FetchTotals.php
@@ -13,6 +13,8 @@ class FetchTotals extends Command
 
     protected $description = 'Fetch totals for all our NPM packages';
 
+    private $packageUrl = "https://spatie.be/en/api/packages";
+
     public function handle()
     {
         $npmStats = new NpmStats(new Client());
@@ -26,7 +28,6 @@ class FetchTotals extends Command
          * incomplete or weird data in some cases
          *
          */
-
 
         $totals = $packageList->map(function ($packageName) use ($npmStats) {
             return [
@@ -47,24 +48,12 @@ class FetchTotals extends Command
 
     private function getPackageList()
     {
-        return collect([
-            "spatie-scss",
-            "form-backend-validation",
-            "vue-save-state",
-            "@spatie/blender-js",
-            "npm-install-peers",
-            "eslint-config-spatie",
-            "vue-tabs-component",
-            "@spatie/blender-css",
-            "vue-expose-inject",
-            "@spatie/blender-media",
-            "vue-table-component",
-            "@spatie/blender-content-blocks",
-            "font-awesome-filetypes",
-            "@spatie/attachment-uploader",
-            "postcss-assign",
-            "@spatie/scss",
-            "spatie-dom"
-        ]);
+        return collect(json_decode((new Client())->get($this->packageUrl)->getBody()->getContents()))
+            ->filter(function ($package) {
+                return $package->type === "javascript";
+            })
+            ->map(function ($package) {
+                return $package->name;
+            });
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         \App\Console\Components\Calendar\FetchCalendarEvents::class,
         \App\Console\Components\GitHub\FetchTotals::class,
         \App\Console\Components\InternetConnection\SendHeartbeat::class,
+        \App\Console\Components\Npm\FetchTotals::class,
         \App\Console\Components\Music\FetchCurrentTrack::class,
         \App\Console\Components\Packagist\FetchTotals::class,
         \App\Console\Components\Tasks\FetchTasks::class,

--- a/app/Events/Npm/TotalsFetched.php
+++ b/app/Events/Npm/TotalsFetched.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Events\Npm;
+
+use App\Events\DashboardEvent;
+
+class TotalsFetched extends DashboardEvent
+{
+    /** @var int */
+    public $daily;
+
+    /** @var int */
+    public $monthly;
+
+    /** @var int */
+    public $total;
+
+    public function __construct(array $totals)
+    {
+        foreach ($totals as $sumName => $total) {
+            $this->$sumName = $total;
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,78 +1,78 @@
 {
-  "name": "laravel/laravel",
-  "description": "The Laravel Framework.",
-  "keywords": [
-    "framework",
-    "laravel"
-  ],
-  "license": "MIT",
-  "type": "project",
-  "require": {
-    "php": ">=7.0.0",
-    "barryvdh/laravel-ide-helper": "^2.1",
-    "developmint/npm-stats-api": "^1.0",
-    "erusev/parsedown": "^1.6",
-    "fennb/phirehose": "^1.0",
-    "fideloper/proxy": "~3.3",
-    "guzzlehttp/guzzle": "^6.2",
-    "knplabs/github-api": "^2.4",
-    "laravel/framework": "5.5.*",
-    "laravel/tinker": "~1.0",
-    "pda/pheanstalk": "^3.1",
-    "php-http/guzzle6-adapter": "^1.1",
-    "pusher/pusher-php-server": "^3.0",
-    "spatie/laravel-blade-javascript": "^2.0",
-    "spatie/laravel-google-calendar": "^2.0",
-    "spatie/laravel-tail": "^2.0",
-    "spatie/laravel-twitter-streaming-api": "^0.0.2",
-    "spatie/last-fm-now-playing": "^1.0",
-    "spatie/packagist-api": "^1.0.1",
-    "spatie/valuestore": "^1.1"
-  },
-  "require-dev": {
-    "fzaninotto/faker": "~1.4",
-    "mockery/mockery": "0.9.*",
-    "phpunit/phpunit": "~6.0",
-    "filp/whoops": "~2.0"
-  },
-  "autoload": {
-    "classmap": [
-      "database",
-      "vendor/fennb/phirehose/lib"
+    "name": "laravel/laravel",
+    "description": "The Laravel Framework.",
+    "keywords": [
+        "framework",
+        "laravel"
     ],
-    "psr-4": {
-      "App\\": "app/",
-      "Tests\\": "tests/"
+    "license": "MIT",
+    "type": "project",
+    "require": {
+        "php": ">=7.0.0",
+        "barryvdh/laravel-ide-helper": "^2.1",
+        "developmint/npm-stats-api": "^1.0",
+        "erusev/parsedown": "^1.6",
+        "fennb/phirehose": "^1.0",
+        "fideloper/proxy": "~3.3",
+        "guzzlehttp/guzzle": "^6.2",
+        "knplabs/github-api": "^2.4",
+        "laravel/framework": "5.5.*",
+        "laravel/tinker": "~1.0",
+        "pda/pheanstalk": "^3.1",
+        "php-http/guzzle6-adapter": "^1.1",
+        "pusher/pusher-php-server": "^3.0",
+        "spatie/laravel-blade-javascript": "^2.0",
+        "spatie/laravel-google-calendar": "^2.0",
+        "spatie/laravel-tail": "^2.0",
+        "spatie/laravel-twitter-streaming-api": "^0.0.2",
+        "spatie/last-fm-now-playing": "^1.0",
+        "spatie/packagist-api": "^1.0.1",
+        "spatie/valuestore": "^1.1"
     },
-    "files": [
-      "app/helpers.php"
-    ]
-  },
-  "autoload-dev": {
-    "classmap": [
-      "tests/TestCase.php"
-    ]
-  },
-  "scripts": {
-    "post-root-package-install": [
-      "php -r \"copy('.env.example', '.env');\""
-    ],
-    "post-create-project-cmd": [
-      "php artisan key:generate"
-    ],
-    "laravel-echo-server": "laravel-echo-server start",
-    "post-autoload-dump": [
-      "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-      "@php artisan package:discover"
-    ]
-  },
-  "config": {
-    "preferred-install": "dist",
-    "sort-packages": true
-  },
-  "extra": {
-    "laravel": {
-      "dont-discover": []
+    "require-dev": {
+        "fzaninotto/faker": "~1.4",
+        "mockery/mockery": "0.9.*",
+        "phpunit/phpunit": "~6.0",
+        "filp/whoops": "~2.0"
+    },
+    "autoload": {
+        "classmap": [
+            "database",
+            "vendor/fennb/phirehose/lib"
+        ],
+        "psr-4": {
+            "App\\": "app/",
+            "Tests\\": "tests/"
+        },
+        "files": [
+            "app/helpers.php"
+        ]
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/TestCase.php"
+        ]
+    },
+    "scripts": {
+        "post-root-package-install": [
+            "php -r \"copy('.env.example', '.env');\""
+        ],
+        "post-create-project-cmd": [
+            "php artisan key:generate"
+        ],
+        "laravel-echo-server": "laravel-echo-server start",
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover"
+        ]
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
     }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,78 +1,78 @@
 {
-    "name": "laravel/laravel",
-    "description": "The Laravel Framework.",
-    "keywords": [
-        "framework",
-        "laravel"
+  "name": "laravel/laravel",
+  "description": "The Laravel Framework.",
+  "keywords": [
+    "framework",
+    "laravel"
+  ],
+  "license": "MIT",
+  "type": "project",
+  "require": {
+    "php": ">=7.0.0",
+    "barryvdh/laravel-ide-helper": "^2.1",
+    "developmint/npm-stats-api": "^1.0",
+    "erusev/parsedown": "^1.6",
+    "fennb/phirehose": "^1.0",
+    "fideloper/proxy": "~3.3",
+    "guzzlehttp/guzzle": "^6.2",
+    "knplabs/github-api": "^2.4",
+    "laravel/framework": "5.5.*",
+    "laravel/tinker": "~1.0",
+    "pda/pheanstalk": "^3.1",
+    "php-http/guzzle6-adapter": "^1.1",
+    "pusher/pusher-php-server": "^3.0",
+    "spatie/laravel-blade-javascript": "^2.0",
+    "spatie/laravel-google-calendar": "^2.0",
+    "spatie/laravel-tail": "^2.0",
+    "spatie/laravel-twitter-streaming-api": "^0.0.2",
+    "spatie/last-fm-now-playing": "^1.0",
+    "spatie/packagist-api": "^1.0.1",
+    "spatie/valuestore": "^1.1"
+  },
+  "require-dev": {
+    "fzaninotto/faker": "~1.4",
+    "mockery/mockery": "0.9.*",
+    "phpunit/phpunit": "~6.0",
+    "filp/whoops": "~2.0"
+  },
+  "autoload": {
+    "classmap": [
+      "database",
+      "vendor/fennb/phirehose/lib"
     ],
-    "license": "MIT",
-    "type": "project",
-    "require": {
-        "php": ">=7.0.0",
-        "barryvdh/laravel-ide-helper": "^2.1",
-        "developmint/npm-stats-api": "^1.0",
-        "erusev/parsedown": "^1.6",
-        "fennb/phirehose": "^1.0",
-        "fideloper/proxy": "~3.3",
-        "guzzlehttp/guzzle": "^6.2",
-        "knplabs/github-api": "^2.4",
-        "laravel/framework": "5.5.*",
-        "laravel/tinker": "~1.0",
-        "pda/pheanstalk": "^3.1",
-        "php-http/guzzle6-adapter": "^1.1",
-        "pusher/pusher-php-server": "^3.0",
-        "spatie/laravel-blade-javascript": "^2.0",
-        "spatie/laravel-google-calendar": "^2.0",
-        "spatie/laravel-tail": "^2.0",
-        "spatie/laravel-twitter-streaming-api": "^0.0.2",
-        "spatie/last-fm-now-playing": "^1.0",
-        "spatie/packagist-api": "^1.0.1",
-        "spatie/valuestore": "^1.1"
+    "psr-4": {
+      "App\\": "app/",
+      "Tests\\": "tests/"
     },
-    "require-dev": {
-        "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~6.0",
-        "filp/whoops": "~2.0"
-    },
-    "autoload": {
-        "classmap": [
-            "database",
-            "vendor/fennb/phirehose/lib"
-        ],
-        "psr-4": {
-            "App\\": "app/",
-            "Tests\\": "tests/"
-        },
-        "files": [
-            "app/helpers.php"
-        ]
-    },
-    "autoload-dev": {
-        "classmap": [
-            "tests/TestCase.php"
-        ]
-    },
-    "scripts": {
-        "post-root-package-install": [
-            "php -r \"copy('.env.example', '.env');\""
-        ],
-        "post-create-project-cmd": [
-            "php artisan key:generate"
-        ],
-        "laravel-echo-server": "laravel-echo-server start",
-        "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover"
-        ]
-    },
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "dont-discover": []
-        }
+    "files": [
+      "app/helpers.php"
+    ]
+  },
+  "autoload-dev": {
+    "classmap": [
+      "tests/TestCase.php"
+    ]
+  },
+  "scripts": {
+    "post-root-package-install": [
+      "php -r \"copy('.env.example', '.env');\""
+    ],
+    "post-create-project-cmd": [
+      "php artisan key:generate"
+    ],
+    "laravel-echo-server": "laravel-echo-server start",
+    "post-autoload-dump": [
+      "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+      "@php artisan package:discover"
+    ]
+  },
+  "config": {
+    "preferred-install": "dist",
+    "sort-packages": true
+  },
+  "extra": {
+    "laravel": {
+      "dont-discover": []
     }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,10 @@
     "require": {
         "php": ">=7.0.0",
         "barryvdh/laravel-ide-helper": "^2.1",
+        "developmint/npm-stats-api": "^1.0",
         "erusev/parsedown": "^1.6",
         "fennb/phirehose": "^1.0",
+        "fideloper/proxy": "~3.3",
         "guzzlehttp/guzzle": "^6.2",
         "knplabs/github-api": "^2.4",
         "laravel/framework": "5.5.*",
@@ -25,8 +27,7 @@
         "spatie/laravel-twitter-streaming-api": "^0.0.2",
         "spatie/last-fm-now-playing": "^1.0",
         "spatie/packagist-api": "^1.0.1",
-        "spatie/valuestore": "^1.1",
-        "fideloper/proxy": "~3.3"
+        "spatie/valuestore": "^1.1"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a2151598b4a61c3c3ceba868740b3139",
+    "hash": "61cc1b772051aaa5ef7e7ed70da49dce",
     "content-hash": "39c023a3417f787895f7f7d7c0c1ecc8",
     "packages": [
         {
@@ -183,16 +183,16 @@
         },
         {
             "name": "developmint/npm-stats-api",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Developmint/npm-stats-api.git",
-                "reference": "120da1510c62688c2fa4431fd801fcababae6a35"
+                "reference": "8dede867a81bf178c1c89541e75bccaf16135004"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Developmint/npm-stats-api/zipball/120da1510c62688c2fa4431fd801fcababae6a35",
-                "reference": "120da1510c62688c2fa4431fd801fcababae6a35",
+                "url": "https://api.github.com/repos/Developmint/npm-stats-api/zipball/8dede867a81bf178c1c89541e75bccaf16135004",
+                "reference": "8dede867a81bf178c1c89541e75bccaf16135004",
                 "shasum": ""
             },
             "require": {
@@ -228,7 +228,7 @@
                 "npm",
                 "stats"
             ],
-            "time": "2017-10-11 18:38:05"
+            "time": "2017-10-11 20:59:56"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -728,16 +728,16 @@
         },
         {
             "name": "google/auth",
-            "version": "v1.0.1",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/google/google-auth-library-php.git",
-                "reference": "db8e3022a308cb0e988026d38e67b91a42b41622"
+                "reference": "548d27d670f0236dc5258fa4cdde6e7b63464cfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/google/google-auth-library-php/zipball/db8e3022a308cb0e988026d38e67b91a42b41622",
-                "reference": "db8e3022a308cb0e988026d38e67b91a42b41622",
+                "url": "https://api.github.com/repos/google/google-auth-library-php/zipball/548d27d670f0236dc5258fa4cdde6e7b63464cfd",
+                "reference": "548d27d670f0236dc5258fa4cdde6e7b63464cfd",
                 "shasum": ""
             },
             "require": {
@@ -754,9 +754,6 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "psr-4": {
                     "Google\\Auth\\": "src"
                 }
@@ -772,7 +769,7 @@
                 "google",
                 "oauth2"
             ],
-            "time": "2017-07-31 16:34:40"
+            "time": "2017-10-10 17:01:45"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "61cc1b772051aaa5ef7e7ed70da49dce",
+    "hash": "a2151598b4a61c3c3ceba868740b3139",
     "content-hash": "39c023a3417f787895f7f7d7c0c1ecc8",
     "packages": [
         {
@@ -183,16 +183,16 @@
         },
         {
             "name": "developmint/npm-stats-api",
-            "version": "v1.0.1",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Developmint/npm-stats-api.git",
-                "reference": "8dede867a81bf178c1c89541e75bccaf16135004"
+                "reference": "df9127031cffce662805c474b4d71bb13b8457f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Developmint/npm-stats-api/zipball/8dede867a81bf178c1c89541e75bccaf16135004",
-                "reference": "8dede867a81bf178c1c89541e75bccaf16135004",
+                "url": "https://api.github.com/repos/Developmint/npm-stats-api/zipball/df9127031cffce662805c474b4d71bb13b8457f4",
+                "reference": "df9127031cffce662805c474b4d71bb13b8457f4",
                 "shasum": ""
             },
             "require": {
@@ -228,7 +228,7 @@
                 "npm",
                 "stats"
             ],
-            "time": "2017-10-11 20:59:56"
+            "time": "2017-10-11 21:46:30"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a9089e5fb65de13f63abbe7b868f5f3d",
-    "content-hash": "c217928151bba8a7672d175fd07b9970",
+    "hash": "a2151598b4a61c3c3ceba868740b3139",
+    "content-hash": "39c023a3417f787895f7f7d7c0c1ecc8",
     "packages": [
         {
             "name": "barryvdh/laravel-ide-helper",
@@ -180,6 +180,55 @@
                 "stream_filter_register"
             ],
             "time": "2017-08-18 09:54:01"
+        },
+        {
+            "name": "developmint/npm-stats-api",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Developmint/npm-stats-api.git",
+                "reference": "120da1510c62688c2fa4431fd801fcababae6a35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Developmint/npm-stats-api/zipball/120da1510c62688c2fa4431fd801fcababae6a35",
+                "reference": "120da1510c62688c2fa4431fd801fcababae6a35",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Developmint\\NpmStats\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander Lichter",
+                    "email": "alichter@developmint.de",
+                    "homepage": "https://developmint.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Fetch stats for your NPM packages",
+            "homepage": "https://github.com/developmint/npm-stats-api",
+            "keywords": [
+                "api",
+                "developmint",
+                "npm",
+                "stats"
+            ],
+            "time": "2017-10-11 18:38:05"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",

--- a/resources/assets/js/components/Npm.vue
+++ b/resources/assets/js/components/Npm.vue
@@ -1,0 +1,68 @@
+<template>
+    <tile :position="position" modifiers="overflow">
+        <section class="statistics">
+            <h1>NPM Package Stats</h1>
+            <ul>
+                <li class="statistic">
+                    <span class="statistic__label">24 hours</span>
+                    <span class="statistic__count">{{ formatNumber(daily) }}</span>
+                </li>
+                <li class="statistic">
+                    <span class="statistic__label">30 days</span>
+                    <span class="statistic__count">{{ formatNumber(monthly) }}</span>
+                </li>
+                <li class="statistic">
+                    <span class="statistic__label">Total</span>
+                    <span class="statistic__count">{{ formatNumber(total) }}</span>
+                </li>
+            </ul>
+        </section>
+    </tile>
+</template>
+
+<script>
+    import { formatNumber } from '../helpers';
+    import echo from '../mixins/echo';
+    import Tile from './atoms/Tile';
+    import saveState from 'vue-save-state';
+
+    export default {
+
+        components: {
+            Tile,
+        },
+
+        mixins: [echo, saveState],
+
+        props: ['position'],
+
+        data() {
+            return {
+                daily: 0,
+                monthly: 0,
+                total: 0,
+            };
+        },
+
+        methods: {
+            formatNumber,
+
+            getEventHandlers() {
+                return {
+                    'Npm.TotalsFetched': response => {
+                        this.daily = response.daily;
+                        this.monthly = response.monthly;
+                        this.total = response.total;
+                    },
+                };
+            },
+
+            getSaveStateConfig() {
+                return {
+                    cacheKey: 'npm',
+                };
+            },
+        },
+    };
+
+</script>

--- a/resources/assets/js/components/Packagist.vue
+++ b/resources/assets/js/components/Packagist.vue
@@ -1,7 +1,7 @@
 <template>
     <tile :position="position" modifiers="overflow">
         <section class="statistics">
-            <h1>Package Stats</h1>
+            <h1>Packagist Package Stats</h1>
             <ul>
                 <li class="statistic">
                     <span class="statistic__label">24 hours</span>


### PR DESCRIPTION
I started to work on a solution for fetching NPM download stats and using them for a packagist-like dashboard tile.

The PR is still WIP, so feedback is very welcome!

Current problems:
+ NPM API only allows bulk request for non-scoped packages (those without @xyz before the name)
+ NPM API has different date range maximums for bulk and non-bulk operations

That's why I currently use a naive approach that takes 3 calls per package. :(

Hope there will be a way around this. Otherwise, the time for the command execution will be hilarious.

**UPDATE 1**:

I'm using bulk operations for non-scoped packages, so those stats (assuming that there are not more than 125 packages) can be retrieved with 3 HTTP calls.

Anyway, the issue with scoped packages persists and there isn't much I can do against because NPM only provides limited API methods.

**UPDATE 2**:

I ditched the bulk logic, added some improvements, and also created a Vue component for the tile.

Reference: #86 