### PR TITLE
Allow user to specify weather temp format

### DIFF
--- a/resources/assets/js/components/TimeWeather.vue
+++ b/resources/assets/js/components/TimeWeather.vue
@@ -30,6 +30,13 @@ export default {
         weatherCity: {
             type: String,
         },
+        weatherFormat: {
+            type: String,
+            default: 'c',
+            validator: function (value) {
+                return ['c', 'f'].indexOf(value.toLowerCase()) !== -1
+            }
+        },
         dateFormat: {
             type: String,
             default: 'DD-MM-YYYY',

--- a/resources/assets/js/services/weather/Weather.js
+++ b/resources/assets/js/services/weather/Weather.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 class Weather {
-    async conditions(city) {
-        const query = `select item.condition from weather.forecast where woeid in (select woeid from geo.places(1) where text='${city}') and u='c'`;
+    async conditions(city, format) {
+        const query = `select item.condition from weather.forecast where woeid in (select woeid from geo.places(1) where text='${city}') and u='${format}'`;
 
         const response = await this.performQuery(query);
 


### PR DESCRIPTION
This PR adds the ability to provide a weather format of `F` for fahrenheit.

Adding `weather-format="f"` to the Vue component will set it to use fahrenheit.

A custom validator was added to the Vue component to allow `c` or `f`.