### PR TITLE
Add timezone option to time-weather tile config

### DIFF
--- a/config/dashboard.php
+++ b/config/dashboard.php
@@ -102,6 +102,7 @@ return [
             'open_weather_map_city' => 'Antwerp',
             'buienradar_latitude' => env('BUIENRADAR_LATITUDE'),
             'buienradar_longitude' => env('BUIENRADAR_LONGITUDE'),
+            'timezone' => 'Europe/Brussels',
         ],
     ],
 ];


### PR DESCRIPTION
## Summary
- Adds a `timezone` key to the `time_weather` tile config, so the time-weather tile can use a configured timezone instead of relying on the system clock
- Corresponds to spatie/laravel-dashboard-time-weather-tile#16